### PR TITLE
Missing @synthesize in _PDRequestState was throwing unrecognized selector exception

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -669,5 +669,6 @@
 @synthesize request = _request;
 @synthesize response = _response;
 @synthesize requestID = _requestID;
+@synthesize dataAccumulator = _dataAccumulator;
 
 @end


### PR DESCRIPTION
Just a one-line fix. Thanks!
