### PR TITLE
Inaccurate Timestamp < iOS 5.1 warning / workaround

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -493,11 +493,13 @@
 {
     [self performBlock:^{
 
-        // If the request wasn't generated yet, then willSendRequest was not called. Send it under the
-        // assumption that there was no response redirection.
-
+        // If the request wasn't generated yet, then willSendRequest was not called. This appears to be an inconsistency in documentation
+        // and behavior.
         NSURLRequest *request = [self requestForConnection:connection];
         if (!request) {
+        
+            NSLog(@"PonyDebugger Warning: -[PDNetworkDomainController connection:willSendRequest:redirectResponse:] not called, request timestamp may be inaccurate. See Known Issues in the README for more information.");
+
             request = connection.currentRequest;
             [self setRequest:request forConnection:connection];
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ The repository contains a test application to demonstrate PonyDebugger's capabil
 ### Known Issues / Improvements
 
  * `CoreData.framework` must be linked, even if you do not use the Core Data browsing functionality.
+ * iOS 5.1 and below: In certain cases, -[NSURLConnectionDataDelegate connection:willSendRequest:redirectResponse:] will never get 
+   called. PonyDebugger requires this call to know when the request was sent, and will warn you with a workaround 
+   that the timestamp is inaccurate.
+
+   To fix the timestamp, make sure that `Accept-Encoding` HTTP header in your `NSURLRequest` is not set (by default, iOS will set it to 
+   `gzip, deflate`, which is usually adequate.
+
+   AFNetworking users: if you subclass `AFHTTPClient`, call `[self setDefaultHeader:@"Accept-Encoding" value:nil];`.
 
 Contributing
 ------------


### PR DESCRIPTION
Adding warning and issue with workaround for inaccurate timestamp
