### PR TITLE
Failed to recurse into submodule path 'ObjC/SocketRocket'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Examples/PDTwitterTest/AFNetworking"]
 	path = Examples/PDTwitterTest/AFNetworking
-	url = git://github.com/AFNetworking/AFNetworking.git
+	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "ObjC/SocketRocket"]
 	path = ObjC/SocketRocket
-	url = git://github.com/square/SocketRocket.git
+	url = https://github.com/square/SocketRocket.git 


### PR DESCRIPTION
Hi,

when I type in:

git submodule update --init --recursive, I get an error with a Permission Denied when trying to clone 'pages'... here is the output from terminal:

Cloning into 'PonyDebugger'...
remote: Counting objects: 498, done.
remote: Compressing objects: 100% (285/285), done.
remote: Total 498 (delta 264), reused 400 (delta 198)
Receiving objects: 100% (498/498), 1.16 MiB | 1.93 MiB/s, done.
Resolving deltas: 100% (264/264), done.
Submodule 'Examples/PDTwitterTest/AFNetworking' (git://github.com/AFNetworking/AFNetworking.git) registered for path 'Examples/PDTwitterTest/AFNetworking'
Submodule 'ObjC/SocketRocket' (git://github.com/square/SocketRocket.git) registered for path 'ObjC/SocketRocket'
Cloning into 'Examples/PDTwitterTest/AFNetworking'...
remote: Counting objects: 4054, done.
remote: Compressing objects: 100% (1370/1370), done.
remote: Total 4054 (delta 2740), reused 3915 (delta 2650)
Receiving objects: 100% (4054/4054), 1.17 MiB | 1.32 MiB/s, done.
Resolving deltas: 100% (2740/2740), done.
Submodule path 'Examples/PDTwitterTest/AFNetworking': checked out 'ad850f0c330ae82171c9502d9e7a3929c2c97c69'
Cloning into 'ObjC/SocketRocket'...
remote: Counting objects: 3409, done.
remote: Compressing objects: 100% (1061/1061), done.
remote: Total 3409 (delta 3105), reused 2599 (delta 2297)
Receiving objects: 100% (3409/3409), 1.42 MiB | 841 KiB/s, done.
Resolving deltas: 100% (3105/3105), done.
Submodule path 'ObjC/SocketRocket': checked out '2fda34cf143cfb272c246ade23ffe688eda40883'
Submodule 'pages' (git@github.com:square/SocketRocket.git) registered for path 'pages'
Cloning into 'pages'...
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
Clone of 'git@github.com:square/SocketRocket.git' into submodule path 'pages' failed
Failed to recurse into submodule path 'ObjC/SocketRocket'

Thanks for your help...Paul
