### PR TITLE
Add more error info to 'Debugger failed' message

### DIFF
--- a/ObjC/PonyDebugger/PDDebugger.m
+++ b/ObjC/PonyDebugger/PDDebugger.m
@@ -174,7 +174,7 @@ static NSString *const PDClientIDKey = @"com.squareup.PDDebugger.clientID";
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
 {
-    NSLog(@"Debugger failed");
+    NSLog(@"Debugger failed with web socket error: %@", [error localizedDescription]);
     _socket.delegate = nil;
     _socket = nil;
 }


### PR DESCRIPTION
When adding Pony to an existing project I got a 'Debugger failed' message.  I had this working in other projects so I was a bit surprised.  In any case after looking into it I noticed there is error info so that should be outputted as well to help the user diagnose the issue.
