### PR TITLE
Fix for Issue #35

### DIFF
--- a/ObjC/PonyDebugger/PDDOMDomainController.m
+++ b/ObjC/PonyDebugger/PDDOMDomainController.m
@@ -823,7 +823,7 @@ static NSString *const kPDDOMAttributeParsingRegex = @"[\"'](.*)[\"']";
 {
     [[PDDOMDomainController defaultInstance] removeView:[[self subviews] objectAtIndex:index1]];
     [[PDDOMDomainController defaultInstance] removeView:[[self subviews] objectAtIndex:index2]];
-    [self pd_swizzled_exchangeSubviewAtIndex:index1 withSubviewAtIndex:index1];
+    [self pd_swizzled_exchangeSubviewAtIndex:index1 withSubviewAtIndex:index2];
     [[PDDOMDomainController defaultInstance] addView:[[self subviews] objectAtIndex:index1]];
     [[PDDOMDomainController defaultInstance] addView:[[self subviews] objectAtIndex:index2]];
 }


### PR DESCRIPTION
There was a typo in the swizzled UIView method, exchangeSubviewAtIndex:withSubviewAtIndex:, which caused the actual method to be called with the wrong parameters. This fixes issue #35.
