### PR TITLE
Fix possible leak in connectionFinished:

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -458,7 +458,8 @@
 // This removes storing the accumulated request/response from the dictionary so we can release connection
 - (void)connectionFinished:(NSURLConnection *)connection;
 {
-    [_connectionStates removeObjectForKey:connection];
+    NSValue *key = [NSValue valueWithNonretainedObject:connection];
+    [_connectionStates removeObjectForKey:key];
 }
 
 - (void)performBlock:(dispatch_block_t)block;


### PR DESCRIPTION
I'm seeing a memory leak in Instruments that seems to be fixed by updating [_connectionStates removeObjectForKey:connection] to use valueWithNonretainedObject: as used in setObject:forKey: in requestStateForConnection:
