### PR TITLE
Handle in-progress connections with grace

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -510,8 +510,6 @@ static NSArray *prettyStringPrinters = nil;
 {
     NSMutableData *dataAccumulator = [self requestStateForConnection:connection].dataAccumulator;
     
-    NSAssert(dataAccumulator != nil, @"Data accumulator not initialized before adding to it.");
-    
     [dataAccumulator appendData:data];
 }
 
@@ -609,6 +607,8 @@ static NSArray *prettyStringPrinters = nil;
     data = [data copy];
     [self performBlock:^{
         [self addAccumulatedData:data forConnection:connection];
+
+        if ([self accumulatedDataForConnection:connection] == nil) return;
         
         NSNumber *length = [NSNumber numberWithInteger:data.length];
         NSString *requestID = [self requestIDForConnection:connection];


### PR DESCRIPTION
Currently, calling `-[PDDebugger forwardAllNetworkTraffic]` while there are connections in the process of downloading data will trip an assertion the next time these connections receive a chunk of data and cause the application to crash.

This is a small fix to prevent that, by simply ignoring these in-progress connections.
