### PR TITLE
Don't try to add nil persistent store paths to paths array.

### DIFF
--- a/ObjC/PonyDebugger/PDIndexedDBDomainController.m
+++ b/ObjC/PonyDebugger/PDIndexedDBDomainController.m
@@ -190,7 +190,11 @@ static NSString *const PDManagedObjectContextNameUserInfoKey = @"PDManagedObject
 {
     NSMutableArray *paths = [[NSMutableArray alloc] init];
     for (NSPersistentStore *store in context.persistentStoreCoordinator.persistentStores) {
-        [paths addObject:[[context.persistentStoreCoordinator URLForPersistentStore:store].lastPathComponent stringByDeletingPathExtension]];
+        NSURL *url = [context.persistentStoreCoordinator URLForPersistentStore:store];
+        NSString *pathString = [url.lastPathComponent stringByDeletingPathExtension];
+        if (pathString) {
+            [paths addObject:pathString];
+        }
     }
     
     return [paths componentsJoinedByString:@":"];


### PR DESCRIPTION
It's possible for the persistent store to have a nil URL, especially when using AFIncrementalStore. There's no problem with that, except for the crashing when trying to add nil to the paths array.
