### PR TITLE
Fix for crash when having a library that looks like a NSURLConnectionDelegate

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -237,6 +237,10 @@ static NSArray *prettyStringPrinters = nil;
                 continue;
             }
             
+            if (![class instancesRespondToSelector:@selector(currentRequest)]) {
+                continue;
+            }
+            
             for (int selectorIndex = 0; selectorIndex < numSelectors; ++selectorIndex) {
                 if ([class instancesRespondToSelector:selectors[selectorIndex]]) {
                     [self injectIntoDelegateClass:class];


### PR DESCRIPTION
Fix for crash when having a library that looks like a NSURLConnectionDelegate, like PubNub (which does responds to the 2 selectors injectIntoAllNSURLConnectionDelegateClasses checks on, but does not on currentRequest method.
