### PR TITLE
Fix crash in swizzled exchangeSubviewAtIndex:withSubviewAtIndex: 

### DIFF
--- a/ObjC/PonyDebugger/PDDOMDomainController.m
+++ b/ObjC/PonyDebugger/PDDOMDomainController.m
@@ -862,19 +862,19 @@ static NSString *const kPDDOMAttributeParsingRegex = @"[\"'](.*)[\"']";
 {
     // Guard against calls with out-of-bounds indices.
     // exchangeSubviewAtIndex:withSubviewAtIndex: doesn't crash in this case, so neither should we.
-    if (index1 < [[self subviews] count]) {
+    if (index1 >= 0 && index1 < [[self subviews] count]) {
         [[PDDOMDomainController defaultInstance] removeView:[[self subviews] objectAtIndex:index1]];
     }
-    if (index2 < [[self subviews] count]) {
+    if (index2 >= 0 && index2 < [[self subviews] count]) {
         [[PDDOMDomainController defaultInstance] removeView:[[self subviews] objectAtIndex:index2]];
     }
     
     [self pd_swizzled_exchangeSubviewAtIndex:index1 withSubviewAtIndex:index2];
     
-    if (index1 < [[self subviews] count]) {
+    if (index1 >= 0 && index1 < [[self subviews] count]) {
         [[PDDOMDomainController defaultInstance] addView:[[self subviews] objectAtIndex:index1]];
     }
-    if (index2 < [[self subviews] count]) {
+    if (index2 >= 0 && index2 < [[self subviews] count]) {
         [[PDDOMDomainController defaultInstance] addView:[[self subviews] objectAtIndex:index2]];
     }
 }


### PR DESCRIPTION
This method can be called with indices outside the subview array's bounds. In that case, the swizzled method was crashing where the UIView implementation continues without complaining. This change guards against that crash.
