### PR TITLE
View debugging object editing

### DIFF
--- a/Examples/PDTwitterTest/PDTwitterTest/PDAppDelegate.m
+++ b/Examples/PDTwitterTest/PDTwitterTest/PDAppDelegate.m
@@ -49,7 +49,7 @@
     // Enable View Hierarchy debugging. This will swizzle UIView methods to monitor changes in the hierarchy
     // Choose a few UIView key paths to display as attributes of the dom nodes
     [debugger enableViewHierarchyDebugging];
-    [debugger setDisplayedViewAttributeKeyPaths:@[@"frame", @"hidden", @"alpha", @"opaque", @"accessibilityLabel", @"text", @"backgroundColor"]];
+    [debugger setDisplayedViewAttributeKeyPaths:@[@"frame", @"hidden", @"alpha", @"opaque", @"accessibilityLabel", @"text", @"backgroundColor", @"font"]];
     
     // Connect to a specific host
     [debugger connectToURL:[NSURL URLWithString:@"ws://localhost:9000/device"]];

--- a/Examples/PDTwitterTest/PDTwitterTest/PDAppDelegate.m
+++ b/Examples/PDTwitterTest/PDTwitterTest/PDAppDelegate.m
@@ -49,7 +49,7 @@
     // Enable View Hierarchy debugging. This will swizzle UIView methods to monitor changes in the hierarchy
     // Choose a few UIView key paths to display as attributes of the dom nodes
     [debugger enableViewHierarchyDebugging];
-    [debugger setDisplayedViewAttributeKeyPaths:@[@"frame", @"hidden", @"alpha", @"opaque", @"accessibilityLabel", @"text"]];
+    [debugger setDisplayedViewAttributeKeyPaths:@[@"frame", @"hidden", @"alpha", @"opaque", @"accessibilityLabel", @"text", @"backgroundColor"]];
     
     // Connect to a specific host
     [debugger connectToURL:[NSURL URLWithString:@"ws://localhost:9000/device"]];

--- a/ObjC/PonyDebugger.xcodeproj/project.pbxproj
+++ b/ObjC/PonyDebugger.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		9497D18F17DD683900DFA63D /* PDStringFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D18D17DD683900DFA63D /* PDStringFormatter.m */; };
 		9497D19217DD691F00DFA63D /* PDColorFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D19017DD691F00DFA63D /* PDColorFormatter.h */; };
 		9497D19317DD691F00DFA63D /* PDColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D19117DD691F00DFA63D /* PDColorFormatter.m */; };
+		9497D19617DD7ACE00DFA63D /* PDFontFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D19417DD7ACE00DFA63D /* PDFontFormatter.h */; };
+		9497D19717DD7ACE00DFA63D /* PDFontFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D19517DD7ACE00DFA63D /* PDFontFormatter.m */; };
 		E8D8B39316E00C9600081F80 /* PDPrettyStringPrinter.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8D8B39416E00C9600081F80 /* PDPrettyStringPrinter.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */; };
 		F683ADB014FC1B4D008EBBA7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F683ADAF14FC1B4D008EBBA7 /* Foundation.framework */; };
@@ -306,6 +308,8 @@
 		9497D18D17DD683900DFA63D /* PDStringFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDStringFormatter.m; sourceTree = "<group>"; };
 		9497D19017DD691F00DFA63D /* PDColorFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDColorFormatter.h; sourceTree = "<group>"; };
 		9497D19117DD691F00DFA63D /* PDColorFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDColorFormatter.m; sourceTree = "<group>"; };
+		9497D19417DD7ACE00DFA63D /* PDFontFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFontFormatter.h; sourceTree = "<group>"; };
+		9497D19517DD7ACE00DFA63D /* PDFontFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDFontFormatter.m; sourceTree = "<group>"; };
 		E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDPrettyStringPrinter.h; sourceTree = "<group>"; };
 		E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDPrettyStringPrinter.m; sourceTree = "<group>"; };
 		F60EBEA114FC87EE0095B011 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -539,6 +543,8 @@
 				9497D18D17DD683900DFA63D /* PDStringFormatter.m */,
 				9497D19017DD691F00DFA63D /* PDColorFormatter.h */,
 				9497D19117DD691F00DFA63D /* PDColorFormatter.m */,
+				9497D19417DD7ACE00DFA63D /* PDFontFormatter.h */,
+				9497D19517DD7ACE00DFA63D /* PDFontFormatter.m */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -596,6 +602,7 @@
 				3DE2292715D5874C0035A508 /* PDIndexedDBDomainController.h in Headers */,
 				3DE2292915D5874C0035A508 /* PDNetworkDomainController.h in Headers */,
 				3DE2292B15D5874C0035A508 /* PDObject.h in Headers */,
+				9497D19617DD7ACE00DFA63D /* PDFontFormatter.h in Headers */,
 				9497D18A17DD676800DFA63D /* PDGenericObjectFormatter.h in Headers */,
 				3DE2292D15D5874C0035A508 /* PDPageDomainController.h in Headers */,
 				3DE2292F15D5874C0035A508 /* PDRuntimeDomainController.h in Headers */,
@@ -783,6 +790,7 @@
 				2516718515E61023002F2F95 /* PDNetworkTypes.m in Sources */,
 				2516718715E61023002F2F95 /* PDPageDomain.m in Sources */,
 				2516718915E61023002F2F95 /* PDPageTypes.m in Sources */,
+				9497D19717DD7ACE00DFA63D /* PDFontFormatter.m in Sources */,
 				2516718B15E61023002F2F95 /* PDProfilerDomain.m in Sources */,
 				2516718D15E61023002F2F95 /* PDProfilerTypes.m in Sources */,
 				2516718F15E61023002F2F95 /* PDRuntimeDomain.m in Sources */,

--- a/ObjC/PonyDebugger.xcodeproj/project.pbxproj
+++ b/ObjC/PonyDebugger.xcodeproj/project.pbxproj
@@ -125,6 +125,12 @@
 		943D444E160A73810091CA77 /* PDDOMDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = 943D444C160A73810091CA77 /* PDDOMDomainController.m */; };
 		947CE06F163CA24E0035FB90 /* PDInspectorDomainController.h in Headers */ = {isa = PBXBuildFile; fileRef = 947CE06D163CA24E0035FB90 /* PDInspectorDomainController.h */; };
 		947CE070163CA24E0035FB90 /* PDInspectorDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = 947CE06E163CA24E0035FB90 /* PDInspectorDomainController.m */; };
+		9497D17817DD363B00DFA63D /* PDFormatterManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D17617DD363B00DFA63D /* PDFormatterManager.h */; };
+		9497D17917DD363B00DFA63D /* PDFormatterManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D17717DD363B00DFA63D /* PDFormatterManager.m */; };
+		9497D18A17DD676800DFA63D /* PDGenericObjectFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D18817DD676800DFA63D /* PDGenericObjectFormatter.h */; };
+		9497D18B17DD676800DFA63D /* PDGenericObjectFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */; };
+		9497D18E17DD683900DFA63D /* PDStringFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D18C17DD683900DFA63D /* PDStringFormatter.h */; };
+		9497D18F17DD683900DFA63D /* PDStringFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D18D17DD683900DFA63D /* PDStringFormatter.m */; };
 		E8D8B39316E00C9600081F80 /* PDPrettyStringPrinter.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8D8B39416E00C9600081F80 /* PDPrettyStringPrinter.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */; };
 		F683ADB014FC1B4D008EBBA7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F683ADAF14FC1B4D008EBBA7 /* Foundation.framework */; };
@@ -290,6 +296,12 @@
 		943D444C160A73810091CA77 /* PDDOMDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDDOMDomainController.m; sourceTree = "<group>"; };
 		947CE06D163CA24E0035FB90 /* PDInspectorDomainController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDInspectorDomainController.h; sourceTree = "<group>"; };
 		947CE06E163CA24E0035FB90 /* PDInspectorDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDInspectorDomainController.m; sourceTree = "<group>"; };
+		9497D17617DD363B00DFA63D /* PDFormatterManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFormatterManager.h; sourceTree = "<group>"; };
+		9497D17717DD363B00DFA63D /* PDFormatterManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDFormatterManager.m; sourceTree = "<group>"; };
+		9497D18817DD676800DFA63D /* PDGenericObjectFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDGenericObjectFormatter.h; sourceTree = "<group>"; };
+		9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDGenericObjectFormatter.m; sourceTree = "<group>"; };
+		9497D18C17DD683900DFA63D /* PDStringFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDStringFormatter.h; sourceTree = "<group>"; };
+		9497D18D17DD683900DFA63D /* PDStringFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDStringFormatter.m; sourceTree = "<group>"; };
 		E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDPrettyStringPrinter.h; sourceTree = "<group>"; };
 		E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDPrettyStringPrinter.m; sourceTree = "<group>"; };
 		F60EBEA114FC87EE0095B011 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -440,6 +452,7 @@
 				3DE2293315D587540035A508 /* Domain Controllers */,
 				3DE2293415D5876F0035A508 /* PDObject */,
 				25E5BCE016BA41B900152A45 /* Categories */,
+				9497D18417DD669900DFA63D /* Formatters */,
 				3DE228B515D5874C0035A508 /* PDDebugger.h */,
 				3DE228B615D5874C0035A508 /* PDDebugger.m */,
 				3DE228B715D5874C0035A508 /* PDDefinitions.h */,
@@ -448,6 +461,8 @@
 				3DE228BE15D5874C0035A508 /* PDDynamicDebuggerDomain.m */,
 				E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */,
 				E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */,
+				9497D17617DD363B00DFA63D /* PDFormatterManager.h */,
+				9497D17717DD363B00DFA63D /* PDFormatterManager.m */,
 				3DE228C915D5874C0035A508 /* PonyDebugger-Prefix.pch */,
 				3DE228CA15D5874C0035A508 /* PonyDebugger.h */,
 			);
@@ -511,6 +526,17 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		9497D18417DD669900DFA63D /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				9497D18817DD676800DFA63D /* PDGenericObjectFormatter.h */,
+				9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */,
+				9497D18C17DD683900DFA63D /* PDStringFormatter.h */,
+				9497D18D17DD683900DFA63D /* PDStringFormatter.m */,
+			);
+			name = Formatters;
+			sourceTree = "<group>";
+		};
 		F683ADA114FC1B4C008EBBA7 = {
 			isa = PBXGroup;
 			children = (
@@ -564,6 +590,7 @@
 				3DE2292715D5874C0035A508 /* PDIndexedDBDomainController.h in Headers */,
 				3DE2292915D5874C0035A508 /* PDNetworkDomainController.h in Headers */,
 				3DE2292B15D5874C0035A508 /* PDObject.h in Headers */,
+				9497D18A17DD676800DFA63D /* PDGenericObjectFormatter.h in Headers */,
 				3DE2292D15D5874C0035A508 /* PDPageDomainController.h in Headers */,
 				3DE2292F15D5874C0035A508 /* PDRuntimeDomainController.h in Headers */,
 				3DE2293115D5874C0035A508 /* PonyDebugger-Prefix.pch in Headers */,
@@ -579,6 +606,7 @@
 				2516716615E61023002F2F95 /* PDDebuggerDomain.h in Headers */,
 				2516716815E61023002F2F95 /* PDDebuggerTypes.h in Headers */,
 				2516716A15E61023002F2F95 /* PDDOMDebuggerDomain.h in Headers */,
+				9497D18E17DD683900DFA63D /* PDStringFormatter.h in Headers */,
 				2516716C15E61023002F2F95 /* PDDOMDomain.h in Headers */,
 				2516716E15E61023002F2F95 /* PDDOMStorageDomain.h in Headers */,
 				2516717015E61023002F2F95 /* PDDOMStorageTypes.h in Headers */,
@@ -594,6 +622,7 @@
 				2516718415E61023002F2F95 /* PDNetworkTypes.h in Headers */,
 				2516718615E61023002F2F95 /* PDPageDomain.h in Headers */,
 				E8D8B39316E00C9600081F80 /* PDPrettyStringPrinter.h in Headers */,
+				9497D17817DD363B00DFA63D /* PDFormatterManager.h in Headers */,
 				2516718815E61023002F2F95 /* PDPageTypes.h in Headers */,
 				2516718A15E61023002F2F95 /* PDProfilerDomain.h in Headers */,
 				2516718C15E61023002F2F95 /* PDProfilerTypes.h in Headers */,
@@ -724,9 +753,11 @@
 				2516715B15E61023002F2F95 /* PDConsoleDomain.m in Sources */,
 				2516715D15E61023002F2F95 /* PDConsoleTypes.m in Sources */,
 				2516715F15E61023002F2F95 /* PDCSSDomain.m in Sources */,
+				9497D18B17DD676800DFA63D /* PDGenericObjectFormatter.m in Sources */,
 				2516716115E61023002F2F95 /* PDCSSTypes.m in Sources */,
 				2516716315E61023002F2F95 /* PDDatabaseDomain.m in Sources */,
 				2516716515E61023002F2F95 /* PDDatabaseTypes.m in Sources */,
+				9497D18F17DD683900DFA63D /* PDStringFormatter.m in Sources */,
 				2516716715E61023002F2F95 /* PDDebuggerDomain.m in Sources */,
 				2516716915E61023002F2F95 /* PDDebuggerTypes.m in Sources */,
 				2516716B15E61023002F2F95 /* PDDOMDebuggerDomain.m in Sources */,
@@ -753,6 +784,7 @@
 				2516719515E61023002F2F95 /* PDTimelineTypes.m in Sources */,
 				2516719715E61023002F2F95 /* PDWebGLDomain.m in Sources */,
 				2516719915E61023002F2F95 /* PDWebGLTypes.m in Sources */,
+				9497D17917DD363B00DFA63D /* PDFormatterManager.m in Sources */,
 				2516719B15E61023002F2F95 /* PDWorkerDomain.m in Sources */,
 				F6EA51A816124E7D00A27364 /* NSData+PDB64Additions.m in Sources */,
 				943D444E160A73810091CA77 /* PDDOMDomainController.m in Sources */,

--- a/ObjC/PonyDebugger.xcodeproj/project.pbxproj
+++ b/ObjC/PonyDebugger.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		9497D18B17DD676800DFA63D /* PDGenericObjectFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */; };
 		9497D18E17DD683900DFA63D /* PDStringFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D18C17DD683900DFA63D /* PDStringFormatter.h */; };
 		9497D18F17DD683900DFA63D /* PDStringFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D18D17DD683900DFA63D /* PDStringFormatter.m */; };
+		9497D19217DD691F00DFA63D /* PDColorFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497D19017DD691F00DFA63D /* PDColorFormatter.h */; };
+		9497D19317DD691F00DFA63D /* PDColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9497D19117DD691F00DFA63D /* PDColorFormatter.m */; };
 		E8D8B39316E00C9600081F80 /* PDPrettyStringPrinter.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8D8B39416E00C9600081F80 /* PDPrettyStringPrinter.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */; };
 		F683ADB014FC1B4D008EBBA7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F683ADAF14FC1B4D008EBBA7 /* Foundation.framework */; };
@@ -302,6 +304,8 @@
 		9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDGenericObjectFormatter.m; sourceTree = "<group>"; };
 		9497D18C17DD683900DFA63D /* PDStringFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDStringFormatter.h; sourceTree = "<group>"; };
 		9497D18D17DD683900DFA63D /* PDStringFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDStringFormatter.m; sourceTree = "<group>"; };
+		9497D19017DD691F00DFA63D /* PDColorFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDColorFormatter.h; sourceTree = "<group>"; };
+		9497D19117DD691F00DFA63D /* PDColorFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDColorFormatter.m; sourceTree = "<group>"; };
 		E8D8B39116E00C9600081F80 /* PDPrettyStringPrinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDPrettyStringPrinter.h; sourceTree = "<group>"; };
 		E8D8B39216E00C9600081F80 /* PDPrettyStringPrinter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDPrettyStringPrinter.m; sourceTree = "<group>"; };
 		F60EBEA114FC87EE0095B011 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -533,6 +537,8 @@
 				9497D18917DD676800DFA63D /* PDGenericObjectFormatter.m */,
 				9497D18C17DD683900DFA63D /* PDStringFormatter.h */,
 				9497D18D17DD683900DFA63D /* PDStringFormatter.m */,
+				9497D19017DD691F00DFA63D /* PDColorFormatter.h */,
+				9497D19117DD691F00DFA63D /* PDColorFormatter.m */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -631,6 +637,7 @@
 				2516719215E61023002F2F95 /* PDTimelineDomain.h in Headers */,
 				2516719415E61023002F2F95 /* PDTimelineTypes.h in Headers */,
 				2516719615E61023002F2F95 /* PDWebGLDomain.h in Headers */,
+				9497D19217DD691F00DFA63D /* PDColorFormatter.h in Headers */,
 				2516719815E61023002F2F95 /* PDWebGLTypes.h in Headers */,
 				2516719A15E61023002F2F95 /* PDWorkerDomain.h in Headers */,
 				F6EA51A716124E7D00A27364 /* NSData+PDB64Additions.h in Headers */,
@@ -786,6 +793,7 @@
 				2516719915E61023002F2F95 /* PDWebGLTypes.m in Sources */,
 				9497D17917DD363B00DFA63D /* PDFormatterManager.m in Sources */,
 				2516719B15E61023002F2F95 /* PDWorkerDomain.m in Sources */,
+				9497D19317DD691F00DFA63D /* PDColorFormatter.m in Sources */,
 				F6EA51A816124E7D00A27364 /* NSData+PDB64Additions.m in Sources */,
 				943D444E160A73810091CA77 /* PDDOMDomainController.m in Sources */,
 				947CE070163CA24E0035FB90 /* PDInspectorDomainController.m in Sources */,

--- a/ObjC/PonyDebugger/PDColorFormatter.h
+++ b/ObjC/PonyDebugger/PDColorFormatter.h
@@ -1,0 +1,19 @@
+//
+//  PDColorFormatter.h
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, PDColorFormatterStyle) {
+    PDColorFormatterStyleARGBHex = 0
+};
+
+@interface PDColorFormatter : NSFormatter
+
+@property (nonatomic, assign) PDColorFormatterStyle style;
+
+@end

--- a/ObjC/PonyDebugger/PDColorFormatter.m
+++ b/ObjC/PonyDebugger/PDColorFormatter.m
@@ -1,0 +1,77 @@
+//
+//  PDColorFormatter.m
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import "PDColorFormatter.h"
+#import <UIKit/UIKit.h>
+
+@implementation PDColorFormatter
+
+- (BOOL)getObjectValue:(out __autoreleasing id *)obj forString:(NSString *)string errorDescription:(out NSString *__autoreleasing *)error
+{
+    BOOL success = NO;
+    switch (self.style) {
+        case PDColorFormatterStyleARGBHex:
+            *obj = [self colorWithArgbHexString:string];
+            success = YES;
+            break;
+            
+        default:
+            break;
+    }
+    return success;
+}
+
+- (NSString *)stringForObjectValue:(id)obj
+{
+    NSString *string = nil;
+    if ([obj isKindOfClass:[UIColor class]]) {
+        switch (self.style) {
+            case PDColorFormatterStyleARGBHex:
+                string = [self argbHexStringForColor:obj];
+                break;
+                
+            default:
+                break;
+        }
+    }
+    return string;
+}
+
+- (UIColor *)colorWithArgbHexString:(NSString *)argbHexString;
+{
+    NSString *numberString = [argbHexString stringByTrimmingCharactersInSet:[[NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEF"] invertedSet]];
+    NSString *const hexPrefix = @"0x";
+    numberString = [hexPrefix stringByAppendingString:numberString];
+    NSScanner *scanner = [NSScanner scannerWithString:numberString];
+    
+    unsigned int intNumber = 0;
+    [scanner scanHexInt:&intNumber];
+    CGFloat alpha = ((intNumber >> 24) & 0xFF) / (float)0xFF;
+    CGFloat red = ((intNumber >> 16) & 0xFF) / (float)0xFF;
+    CGFloat green = ((intNumber >> 8) & 0xFF) / (float)0xFF;
+    CGFloat blue = (intNumber & 0xFF) / (float)0xFF;
+    
+    return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+}
+
+- (NSString *)argbHexStringForColor:(UIColor *)color;
+{
+    CGFloat red, green, blue, alpha, white;
+    NSString *colorString = nil;
+    if ([color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+        unsigned int colorInt = (((int)roundf(alpha * 0xFF)) << 24) | (((int)roundf(red * 0xFF)) << 16) | (((int)roundf(green * 0xFF)) << 8) | (((int)roundf(blue * 0xFF)));
+        colorString = [NSString stringWithFormat:@"#%08X", colorInt];
+    } else if ([color getWhite:&white alpha:&alpha]) {
+        unsigned int colorInt = (((int)roundf(alpha * 0xFF)) << 24) | (((int)roundf(white * 0xFF)) << 16) | (((int)roundf(white * 0xFF)) << 8) | (((int)roundf(white * 0xFF)));
+        colorString = [NSString stringWithFormat:@"#%08X", colorInt];
+    }
+    
+    return colorString;
+}
+
+@end

--- a/ObjC/PonyDebugger/PDDOMDomainController.m
+++ b/ObjC/PonyDebugger/PDDOMDomainController.m
@@ -45,6 +45,8 @@ static NSString *const kPDDOMAttributeParsingRegex = @"[\"'](.*)[\"']";
 
 @property (nonatomic, strong) UIView *inspectModeOverlay;
 
+@property (nonatomic, strong) NSNumberFormatter *numberFormatter;
+
 @end
 
 #pragma mark - Implementation
@@ -80,6 +82,8 @@ static NSString *const kPDDOMAttributeParsingRegex = @"[\"'](.*)[\"']";
         
         [self.inspectModeOverlay addGestureRecognizer:inspectTapGR];
         [self.inspectModeOverlay addGestureRecognizer:inspectPanGR];
+        
+        self.numberFormatter = [[NSNumberFormatter alloc] init];
     }
     return self;
 }
@@ -241,7 +245,7 @@ static NSString *const kPDDOMAttributeParsingRegex = @"[\"'](.*)[\"']";
                 [nodeObject setValue:valueString forKeyPath:name];
             }
         } else {
-            NSNumber *number = @([valueString doubleValue]);
+            NSNumber *number = [self.numberFormatter numberFromString:valueString];
             [nodeObject setValue:number forKeyPath:name];
         }
     }

--- a/ObjC/PonyDebugger/PDFontFormatter.h
+++ b/ObjC/PonyDebugger/PDFontFormatter.h
@@ -1,0 +1,13 @@
+//
+//  PDFontFormatter.h
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PDFontFormatter : NSFormatter
+
+@end

--- a/ObjC/PonyDebugger/PDFontFormatter.m
+++ b/ObjC/PonyDebugger/PDFontFormatter.m
@@ -1,0 +1,53 @@
+//
+//  PDFontFormatter.m
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import "PDFontFormatter.h"
+#import <UIKit/UIKit.h>
+
+static NSString *const kPDFontFormatterParsingRegex = @"(\\S+)\\s+([0-9\\.]+)\\s*pt";
+static NSString *const kPDFontFormatterPrintingFormat = @"%@ %gpt"; // Font name, point size
+static const NSUInteger kPDFontFormatterNumberOfComponents = 2;
+
+@implementation PDFontFormatter
+
+- (BOOL)getObjectValue:(out __autoreleasing id *)obj forString:(NSString *)string errorDescription:(out NSString *__autoreleasing *)error
+{
+    BOOL success = NO;
+    
+    // Try to parse out the font name and point size
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:kPDFontFormatterParsingRegex options:0 error:NULL];
+    NSTextCheckingResult *firstMatch = [regex firstMatchInString:string options:0 range:NSMakeRange(0, [string length])];
+    
+    if (firstMatch && [firstMatch numberOfRanges] == kPDFontFormatterNumberOfComponents + 1) {
+        
+        NSString *fontName = [string substringWithRange:[firstMatch rangeAtIndex:1]];
+        NSString *pointSizeString = [string substringWithRange:[firstMatch rangeAtIndex:2]];
+        NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+        CGFloat pointSize = [[numberFormatter numberFromString:pointSizeString] floatValue];
+        
+        UIFont *font = [UIFont fontWithName:fontName size:pointSize];
+        if (font) {
+            *obj = font;
+            success = YES;
+        }
+    }
+    
+    return success;
+}
+
+- (NSString *)stringForObjectValue:(id)obj
+{
+    NSString *string = nil;
+    if ([obj isKindOfClass:[UIFont class]]) {
+        UIFont *font = obj;
+        string = [NSString stringWithFormat:kPDFontFormatterPrintingFormat, font.fontName, font.pointSize];
+    }
+    return string;
+}
+
+@end

--- a/ObjC/PonyDebugger/PDFormatterManager.h
+++ b/ObjC/PonyDebugger/PDFormatterManager.h
@@ -1,0 +1,20 @@
+//
+//  PDFormatterManager.h
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PDFormatterManager : NSObject
+
++ (instancetype)defaultInstance;
+
+- (void)registerPonyFormatter:(NSFormatter *)formatter forObjectsOfKind:(Class)aClass;
+
+// Walks up the class tree (starting with aClass) until it finds a registered formatter
+- (NSFormatter *)formatterForClass:(Class)aClass;
+
+@end

--- a/ObjC/PonyDebugger/PDFormatterManager.m
+++ b/ObjC/PonyDebugger/PDFormatterManager.m
@@ -7,8 +7,10 @@
 //
 
 #import "PDFormatterManager.h"
+#import <UIKit/UIKit.h>
 #import "PDGenericObjectFormatter.h"
 #import "PDStringFormatter.h"
+#import "PDColorFormatter.h"
 
 @interface PDFormatterManager ()
 
@@ -31,6 +33,10 @@
         
         PDStringFormatter *stringFormatter = [[PDStringFormatter alloc] init];
         [formatterManager registerPonyFormatter:stringFormatter forObjectsOfKind:[NSString class]];
+        
+        PDColorFormatter *colorFormatter = [[PDColorFormatter alloc] init];
+        colorFormatter.style = PDColorFormatterStyleARGBHex;
+        [formatterManager registerPonyFormatter:colorFormatter forObjectsOfKind:[UIColor class]];
     });
     return formatterManager;
 }

--- a/ObjC/PonyDebugger/PDFormatterManager.m
+++ b/ObjC/PonyDebugger/PDFormatterManager.m
@@ -1,0 +1,64 @@
+//
+//  PDFormatterManager.m
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import "PDFormatterManager.h"
+#import "PDGenericObjectFormatter.h"
+#import "PDStringFormatter.h"
+
+@interface PDFormatterManager ()
+
+@property (nonatomic, strong) NSDictionary *ponyFormatters;
+
+@end
+
+@implementation PDFormatterManager
+
++ (instancetype)defaultInstance;
+{
+    static PDFormatterManager *formatterManager;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatterManager = [[PDFormatterManager alloc] init];
+        
+        // Register the default formatters
+        PDGenericObjectFormatter *genericFormatter = [[PDGenericObjectFormatter alloc] init];
+        [formatterManager registerPonyFormatter:genericFormatter forObjectsOfKind:[NSObject class]];
+        
+        PDStringFormatter *stringFormatter = [[PDStringFormatter alloc] init];
+        [formatterManager registerPonyFormatter:stringFormatter forObjectsOfKind:[NSString class]];
+    });
+    return formatterManager;
+}
+
+- (void)registerPonyFormatter:(NSFormatter *)formatter forObjectsOfKind:(Class)aClass;
+{
+    NSMutableDictionary *newFormatters = nil;
+    if (self.ponyFormatters) {
+       newFormatters = [self.ponyFormatters mutableCopy];
+    } else {
+        newFormatters = [NSMutableDictionary dictionary];
+    }
+    [newFormatters setObject:formatter forKey:(id <NSCopying>)aClass];
+    self.ponyFormatters = [NSDictionary dictionaryWithDictionary:newFormatters];
+}
+
+- (NSFormatter *)formatterForClass:(Class)aClass;
+{
+    Class currentClass = aClass;
+    NSFormatter *foundFormatter = nil;
+    
+    // Move up the class tree until we find a suitable formatter or hit the top of the tree
+    while (!foundFormatter && currentClass) {
+        foundFormatter = [self.ponyFormatters objectForKey:currentClass];
+        currentClass = [currentClass superclass];
+    }
+    
+    return foundFormatter;
+}
+
+@end

--- a/ObjC/PonyDebugger/PDFormatterManager.m
+++ b/ObjC/PonyDebugger/PDFormatterManager.m
@@ -11,6 +11,7 @@
 #import "PDGenericObjectFormatter.h"
 #import "PDStringFormatter.h"
 #import "PDColorFormatter.h"
+#import "PDFontFormatter.h"
 
 @interface PDFormatterManager ()
 
@@ -37,6 +38,9 @@
         PDColorFormatter *colorFormatter = [[PDColorFormatter alloc] init];
         colorFormatter.style = PDColorFormatterStyleARGBHex;
         [formatterManager registerPonyFormatter:colorFormatter forObjectsOfKind:[UIColor class]];
+        
+        PDFontFormatter *fontFormatter = [[PDFontFormatter alloc] init];
+        [formatterManager registerPonyFormatter:fontFormatter forObjectsOfKind:[UIFont class]];
     });
     return formatterManager;
 }

--- a/ObjC/PonyDebugger/PDFormatterManager.m
+++ b/ObjC/PonyDebugger/PDFormatterManager.m
@@ -41,6 +41,12 @@
         
         PDFontFormatter *fontFormatter = [[PDFontFormatter alloc] init];
         [formatterManager registerPonyFormatter:fontFormatter forObjectsOfKind:[UIFont class]];
+        
+        NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+        [formatterManager registerPonyFormatter:numberFormatter forObjectsOfKind:[NSNumber class]];
+        
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [formatterManager registerPonyFormatter:dateFormatter forObjectsOfKind:[NSDate class]];
     });
     return formatterManager;
 }

--- a/ObjC/PonyDebugger/PDGenericObjectFormatter.h
+++ b/ObjC/PonyDebugger/PDGenericObjectFormatter.h
@@ -1,0 +1,13 @@
+//
+//  PDGenericObjectFormatter.h
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PDGenericObjectFormatter : NSFormatter
+
+@end

--- a/ObjC/PonyDebugger/PDGenericObjectFormatter.m
+++ b/ObjC/PonyDebugger/PDGenericObjectFormatter.m
@@ -1,0 +1,24 @@
+//
+//  PDGenericObjectFormatter.m
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import "PDGenericObjectFormatter.h"
+
+@implementation PDGenericObjectFormatter
+
+- (BOOL)getObjectValue:(out __autoreleasing id *)obj forString:(NSString *)string errorDescription:(out NSString *__autoreleasing *)error
+{
+    // Editing not supported
+    return NO;
+}
+
+- (NSString *)stringForObjectValue:(id)obj
+{
+    return [obj description];
+}
+
+@end

--- a/ObjC/PonyDebugger/PDStringFormatter.h
+++ b/ObjC/PonyDebugger/PDStringFormatter.h
@@ -1,0 +1,13 @@
+//
+//  PDStringFormatter.h
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PDStringFormatter : NSFormatter
+
+@end

--- a/ObjC/PonyDebugger/PDStringFormatter.m
+++ b/ObjC/PonyDebugger/PDStringFormatter.m
@@ -1,0 +1,28 @@
+//
+//  PDStringFormatter.m
+//  PonyDebugger
+//
+//  Created by Ryan Olson on 9/8/13.
+//
+//
+
+#import "PDStringFormatter.h"
+
+@implementation PDStringFormatter
+
+- (BOOL)getObjectValue:(out __autoreleasing id *)obj forString:(NSString *)string errorDescription:(out NSString *__autoreleasing *)error
+{
+    *obj = [string copy];
+    return YES;
+}
+
+- (NSString *)stringForObjectValue:(id)obj
+{
+    NSString *string = nil;
+    if ([obj isKindOfClass:[NSString class]]) {
+        string = [obj copy];
+    }
+    return string;
+}
+
+@end


### PR DESCRIPTION
View hierarchy debugging previously only supported editing for primitives, several common structs, and NSStrings. This change allows users to edit arbitrary object types by registering NSFormatter subclassses. Default formatters are provided for NSObject, NSString, NSNumber, NSDate, UIColor, and UIFont. The formatters provide the mapping from object to string and from string to object. A formatter is selected for an object by walking up its class chain and checking the registered formatters for a match. In this way, more specific formatters are preferred, with fallback to a general formatter. Not all formatters support editing - see PDGenericObjectFormatter for an example.

The formatter manager class is intentionally separated from the view hierarchy debugging code. I am thinking that the formatting logic could be useful for adding editing support to other parts of PonyDebugger, though I have not yet looked into doing that.