### PR TITLE
Add support for superclass properties

### DIFF
--- a/ObjC/PonyDebugger/NSArray+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSArray+PDRuntimePropertyDescriptor.h
@@ -17,7 +17,7 @@
 @interface NSArray (PDRuntimePropertyDescriptor)
 
 - (id)PD_valueForKey:(NSString *)key;
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 - (PDRuntimePropertyDescriptor *)PD_propertyDescriptorForPropertyObject:(NSObject *)property;
 
 @end

--- a/ObjC/PonyDebugger/NSArray+PDRuntimePropertyDescriptor.m
+++ b/ObjC/PonyDebugger/NSArray+PDRuntimePropertyDescriptor.m
@@ -36,7 +36,7 @@
     return nil;
 }
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 {
     NSMutableArray *properties = [[NSMutableArray alloc] initWithCapacity:self.count];
     

--- a/ObjC/PonyDebugger/NSDictionary+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSDictionary+PDRuntimePropertyDescriptor.h
@@ -16,7 +16,7 @@
 
 @interface NSDictionary (PDRuntimePropertyDescriptor)
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 - (PDRuntimePropertyDescriptor *)PD_propertyDescriptorForPropertyObject:(NSObject *)property;
 
 @end

--- a/ObjC/PonyDebugger/NSDictionary+PDRuntimePropertyDescriptor.m
+++ b/ObjC/PonyDebugger/NSDictionary+PDRuntimePropertyDescriptor.m
@@ -31,7 +31,7 @@
 
 @implementation NSDictionary (PDRuntimePropertyDescriptor)
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 {
     NSMutableArray *properties = [[NSMutableArray alloc] initWithCapacity:self.count];
     

--- a/ObjC/PonyDebugger/NSManagedObject+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSManagedObject+PDRuntimePropertyDescriptor.h
@@ -18,7 +18,7 @@
 
 @interface NSManagedObject (PDRuntimePropertyDescriptor)
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 - (PDRuntimePropertyDescriptor *)PD_propertyDescriptorForPropertyObject:(NSObject *)property;
 
 - (PDRuntimeRemoteObject *)PD_propertyDescriptorValueForPropertyDescription:(NSPropertyDescription *)property;

--- a/ObjC/PonyDebugger/NSManagedObject+PDRuntimePropertyDescriptor.m
+++ b/ObjC/PonyDebugger/NSManagedObject+PDRuntimePropertyDescriptor.m
@@ -20,9 +20,9 @@
 
 @implementation NSManagedObject (PDRuntimePropertyDescriptor)
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 {
-    NSMutableArray *properties = (NSMutableArray *)[super PD_propertiesForPropertyDescriptors];
+    NSMutableArray *properties = (NSMutableArray *)[super PD_propertiesForPropertyDescriptorsWithOwnProperties:ownProperties];
     if (properties) {
         // NSObject's implementation will catch the @property definitions, so replace those with the
         // NSPropertyDescription instance.

--- a/ObjC/PonyDebugger/NSObject+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSObject+PDRuntimePropertyDescriptor.h
@@ -24,8 +24,8 @@
 
 - (id)PD_valueForKey:(NSString *)key;
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
-- (NSArray *)PD_propertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
+- (NSArray *)PD_propertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 
 - (PDRuntimeRemoteObject *)PD_propertyDescriptorValueForSelector:(SEL)selector;
 - (PDRuntimeRemoteObject *)PD_propertyDescriptorValueForObject:(id)object;

--- a/ObjC/PonyDebugger/NSOrderedSet+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSOrderedSet+PDRuntimePropertyDescriptor.h
@@ -16,7 +16,7 @@
 
 - (id)PD_valueForKey:(NSString *)key;
 - (id)PD_objectAtIndex:(NSUInteger)index;
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 - (PDRuntimePropertyDescriptor *)PD_propertyDescriptorForPropertyObject:(NSObject *)property;
 
 @end

--- a/ObjC/PonyDebugger/NSOrderedSet+PDRuntimePropertyDescriptor.m
+++ b/ObjC/PonyDebugger/NSOrderedSet+PDRuntimePropertyDescriptor.m
@@ -44,7 +44,7 @@
     return nil;
 }
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 {
     NSMutableArray *properties = [[NSMutableArray alloc] initWithCapacity:self.count];
     

--- a/ObjC/PonyDebugger/NSSet+PDRuntimePropertyDescriptor.h
+++ b/ObjC/PonyDebugger/NSSet+PDRuntimePropertyDescriptor.h
@@ -17,7 +17,7 @@
 - (id)PD_valueForKey:(NSString *)key;
 - (id)PD_objectAtIndex:(NSUInteger)index;
 - (NSArray *)PD_sortedArrayRepresentation;
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 - (PDRuntimePropertyDescriptor *)PD_propertyDescriptorForPropertyObject:(NSObject *)property;
 
 @end

--- a/ObjC/PonyDebugger/NSSet+PDRuntimePropertyDescriptor.m
+++ b/ObjC/PonyDebugger/NSSet+PDRuntimePropertyDescriptor.m
@@ -58,7 +58,7 @@
     return nil;
 }
 
-- (NSArray *)PD_propertiesForPropertyDescriptors;
+- (NSArray *)PD_propertiesForPropertyDescriptorsWithOwnProperties:(BOOL)ownProperties;
 {
     NSMutableArray *properties = [[NSMutableArray alloc] initWithCapacity:self.count];
     

--- a/ObjC/PonyDebugger/PDRuntimeDomainController.m
+++ b/ObjC/PonyDebugger/PDRuntimeDomainController.m
@@ -102,7 +102,7 @@
         return;
     }
     
-    NSArray *properties = [object PD_propertyDescriptors];
+    NSArray *properties = [object PD_propertyDescriptorsWithOwnProperties:[ownProperties boolValue]];
     callback(properties, nil);
 }
 


### PR DESCRIPTION
The current implementation only displays the current classes properties, not all of the properties that belong to the superclasses.   There's a simple fix, which doesn't obide by the debugger API, which is to ignore the 'ownProperties', and return all of the properties.    I like this implementation, because it's simple, and unlike javascript, a given instance can not be extended to have additional properties, so it seems (to me) to make sense.  Also, I have yet to have the chrome debugger call getProperties with ownProperties == NO, and if it did, PonyDebugger behavior would not change.

The other fix I had in mind was to change the way PD_propertyDescriptors functioned.  This would return an array of PDRuntimePropertyDescriptor for the immediate properties, and it would register a new object, say PDSuperContainer, that would specify the superclass name and the object it represents.   Then when the browser requested properties on the PDSuperContainer object, a custom PD_propertyDescriptors would return just the properties for the specified class, and another PDSuperContainer if the superclass was not NSObject.

I'd prefer to make the first implementation, since it simpler, however, my first priority is a submit that would be accepted, so I thought I'd see if anyone out here has any preference.

Thoughts?
