### PR TITLE
Allow pip to install pybonjour

### DIFF
--- a/scripts/_bootstrap_contents.py
+++ b/scripts/_bootstrap_contents.py
@@ -7,7 +7,7 @@ def extend_parser(optparse_parser):
 
 def after_install(options, home_dir):
     subprocess.check_call([join(home_dir, 'bin', 'pip'),
-                     'install', '-U', '-e', 'git+https://github.com/square/PonyDebugger.git#egg=ponydebugger'])
+                     'install', '--allow-external', 'pybonjour', '--allow-unverified', 'pybonjour', '-U', '-e', 'git+https://github.com/square/PonyDebugger.git#egg=ponydebugger'])
 
     ponyd_path = join(home_dir, 'bin', 'ponyd')
 


### PR DESCRIPTION
pybonjour is not hosted on PyPI, and pip version 1.5 requires it to now be marked as `--allow-external` and `--allow-unverified` to be installed.
