### PR TITLE
Fallback support for inactive socket

### DIFF
--- a/ObjC/PonyDebugger/PDDebugger.h
+++ b/ObjC/PonyDebugger/PDDebugger.h
@@ -36,6 +36,11 @@
 
 extern void _PDLogObjectsImpl(NSString *severity, NSArray *arguments);
 
+typedef NS_ENUM(NSInteger, PDDebuggerLog) {
+    PDDebuggerLogToSocket = 0,
+    PDDebuggerLogToConsoleWhenDisconnected,
+    PDDebuggerLogToConsoleAlways
+};
 
 #pragma mark - Public Interface
 
@@ -73,5 +78,11 @@ extern void _PDLogObjectsImpl(NSString *severity, NSArray *arguments);
 #pragma mark Remote Logging
 - (void)enableRemoteLogging;
 - (void)clearConsole;
+
+#pragma mark Console Logging
+- (void)enableLogToConsoleWhenDisconnected;
+- (void)enableLogToConsoleAlways;
+- (void)enableLogOnlyToSocket;
+- (int)activeLogOptions;
 
 @end

--- a/ObjC/PonyDebugger/PDDebugger.m
+++ b/ObjC/PonyDebugger/PDDebugger.m
@@ -33,7 +33,9 @@ static NSString *const PDBonjourServiceType = @"_ponyd._tcp";
 
 void _PDLogObjectsImpl(NSString *severity, NSArray *arguments)
 {
-    if([self isConnected]){
+    PDDebugger *connection = [PDDebugger defaultInstance];
+
+    if([connection isConnected]){
       [[PDConsoleDomainController defaultInstance] logWithArguments:arguments severity:severity];
     }else{ // add fallback support to standard NSLog if socket is not active
       NSLog(@"%@",arguments);


### PR DESCRIPTION
The main goal is to allow any user (even if he/she hasn't installed or forget to start ponyd) to be able to still debug any part of the code.

The new few lines make a check about the socket activity and route the output between Ponydebugger and classic NSLog