### PR TITLE
Use Bundle name if Bundle display name isn't set

### DIFF
--- a/ObjC/PonyDebugger/PDDebugger.m
+++ b/ObjC/PonyDebugger/PDDebugger.m
@@ -103,12 +103,13 @@ void _PDLogObjectsImpl(NSString *severity, NSArray *arguments)
     NSString *deviceName = device.name;
 #endif
 
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         clientID, @"device_id",
         deviceName, @"device_name",
         device.localizedModel, @"device_model",
         [[NSBundle mainBundle] bundleIdentifier], @"app_id",
-        [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"], @"app_name",
+        appName, @"app_name",
         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"], @"app_version",
         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], @"app_build",
         nil];


### PR DESCRIPTION
Fixes #127.
