### PR TITLE
Remove `-k` option from curl command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ preference pane.
 
 ```sh
 
-curl -sk https://cloud.github.com/downloads/square/PonyDebugger/bootstrap-ponyd.py | \
+curl -s https://cloud.github.com/downloads/square/PonyDebugger/bootstrap-ponyd.py | \
   python - --ponyd-symlink=/usr/local/bin/ponyd ~/Library/PonyDebugger
 ```
 


### PR DESCRIPTION
GitHub should have a valid certificate anyway, we're executing the result, and the `-k` option causes silent failure on some versions of OS X. Fixes #125.