### PR TITLE
Fixes for iOS 9

### DIFF
--- a/ObjC/PonyDebugger/PDNetworkDomainController.m
+++ b/ObjC/PonyDebugger/PDNetworkDomainController.m
@@ -270,9 +270,15 @@ static NSArray *prettyStringPrinters = nil;
 
 + (void)_swizzleNSURLSessionClasses;
 {
-    Class cfURLSessionConnectionClass = NSClassFromString(@"__NSCFURLSessionConnection");
+    // On iOS 8 we want to swizzle __NSCFURLSessionConnection. On 9 we want to swizzle its subclass, __NSCFURLLocalSessionConnection
+    Class cfURLSessionConnectionClass = NSClassFromString(@"__NSCFURLLocalSessionConnection");
+    
+    if (cfURLSessionConnectionClass == nil) {
+        cfURLSessionConnectionClass = NSClassFromString(@"__NSCFURLSessionConnection");
+
+    }
     if (!cfURLSessionConnectionClass) {
-        PDLog(@"Could not find __NSCFURLSessionConnection");
+        PDLog(@"Could not find __NSCFURLSessionConnection or __NSCFURLLocalSessionConnection");
         return;
     }
     


### PR DESCRIPTION
The methods requiring swizzling are on a subclass now.

Probably need to find a more future-proof way of doing this in the
future