### PR TITLE
Fixing iOS 14 crash due to change in __NSCFURLSessionConnection imple…

### DIFF
--- a/PonyDebugger.podspec
+++ b/PonyDebugger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            =  'PonyDebugger'
-  s.version         =  '0.5'
+  s.version         =  '0.6'
   s.summary         =  'Remote network and data debugging for your native iOS app using Chrome Developer Tools.'
   s.homepage        =  'https://github.com/square/PonyDebugger'
   s.description     =  'PonyDebugger is a remote debugging toolset. It is a client library and gateway server combination that uses Chrome Developer Tools on your browser to debug your application\s network traffic et managed object contexts'


### PR DESCRIPTION
There have been verified reports of PonyDebugger crashing in iOS 14. The visibility of `__NSCFURLSessionConnection`'s `_task` property was changed, so we need to dig deeper to access it, so rather than redeclaring the property as before, we now access it via `[self valueForKey:@"_task"]` in the methods themselves. 

Creating a new property adds other issues, as it breaks the swizzling code, which validates that everything is both `PD_`-prefixed *and* exists in the original class minus the `PD_`. On that note, I fixed a typo in the swizzling code.

This change also works in iOS 13, so I made the changes in the iOS 13 swizzling, rather than have yet another iOS version's worth of swizzles.