### PR TITLE
Updating deployment version to iOS 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.3
+osx_image: xcode11.6
 rvm:
     - 2.4.3
 before_script:

--- a/ObjC/PonyDebugger.xcodeproj/project.pbxproj
+++ b/ObjC/PonyDebugger.xcodeproj/project.pbxproj
@@ -836,7 +836,7 @@
 					"\"$(CONFIGURATION_BUILD_DIR)/usr/local/include\"",
 					./SocketRocket,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PRODUCT_NAME)";
 				SDKROOT = iphoneos;
@@ -883,7 +883,7 @@
 					"\"$(CONFIGURATION_BUILD_DIR)/usr/local/include\"",
 					./SocketRocket,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PRODUCT_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/ObjC/PonyDebugger.xcodeproj/xcshareddata/xcschemes/PonyDebugger.xcscheme
+++ b/ObjC/PonyDebugger.xcodeproj/xcshareddata/xcschemes/PonyDebugger.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:PonyDebugger.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/PonyDebugger.podspec
+++ b/PonyDebugger.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license         =  'Apache License, Version 2.0'
 
   s.requires_arc = true
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.source_files = 'ObjC/{DerivedSources,PonyDebugger}/**/*.{h,m}'
   s.frameworks = 'CoreData', 'CoreGraphics'
   s.dependency 'SocketRocket', '0.5.1'


### PR DESCRIPTION
Because Xcode 12 drops support for iOS 8 deployment target, we need to upgrade PonyDebugger's deployment target.